### PR TITLE
Add missing `post-delete` finalizers to ArgoCD app

### DIFF
--- a/component/app.jsonnet
+++ b/component/app.jsonnet
@@ -4,6 +4,15 @@ local params = inv.parameters.sigstore_policy_controller;
 local argocd = import 'lib/argocd.libjsonnet';
 
 local app = argocd.App('sigstore-policy-controller', params.namespace) {
+  metadata+: {
+    // NOTE(sg): we need to add the post-delete argocd finalizers here since
+    // the application-controller injects them when it sees any post-delete
+    // Helm hooks.
+    finalizers+: [
+      'post-delete-finalizer.argocd.argoproj.io',
+      'post-delete-finalizer.argocd.argoproj.io/cleanup',
+    ],
+  },
   spec+: {
     ignoreDifferences: [
       {

--- a/tests/golden/component-prometheus/sigstore-policy-controller/apps/sigstore-policy-controller.yaml
+++ b/tests/golden/component-prometheus/sigstore-policy-controller/apps/sigstore-policy-controller.yaml
@@ -1,3 +1,7 @@
+metadata:
+  finalizers:
+    - post-delete-finalizer.argocd.argoproj.io
+    - post-delete-finalizer.argocd.argoproj.io/cleanup
 spec:
   ignoreDifferences:
     - group: admissionregistration.k8s.io

--- a/tests/golden/defaults/sigstore-policy-controller/apps/sigstore-policy-controller.yaml
+++ b/tests/golden/defaults/sigstore-policy-controller/apps/sigstore-policy-controller.yaml
@@ -1,3 +1,7 @@
+metadata:
+  finalizers:
+    - post-delete-finalizer.argocd.argoproj.io
+    - post-delete-finalizer.argocd.argoproj.io/cleanup
 spec:
   ignoreDifferences:
     - group: admissionregistration.k8s.io


### PR DESCRIPTION
The Helm chart has some post-delete hooks, so the ArgoCD application controller sets the `post-delete` finalizers. We add those in the App definition to avoid ArgoCD constantly removing and adding those finalizers.

We need to do this because the ArgoCD component library always sets the `resources-finalizer.argocd.argoproj.io` finalizer.



## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
